### PR TITLE
Fix breaking change on current peripheral

### DIFF
--- a/Gormsson/Source/Extensions/Gormsson+CentralManager.swift
+++ b/Gormsson/Source/Extensions/Gormsson+CentralManager.swift
@@ -30,7 +30,9 @@ extension Gormsson: CBCentralManagerDelegate {
                                didDiscover peripheral: CBPeripheral,
                                advertisementData: [String: Any],
                                rssi RSSI: NSNumber) {
-        didDiscoverBlock?(peripheral, GattAdvertisement(with: advertisementData, rssi: RSSI.intValue))
+        let advertisement = GattAdvertisement(with: advertisementData, rssi: RSSI.intValue)
+        lastAdvertisement = advertisement
+        didDiscoverBlock?(peripheral, advertisement)
     }
 
     /// Invoked when an existing connection with a peripheral is torn down.
@@ -43,6 +45,6 @@ extension Gormsson: CBCentralManagerDelegate {
     /// Invoked when a connection is successfully created with a peripheral.
     public func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
         didConnectBlock?(peripheral)
-        current?.0.discoverServices(nil)
+        current?.discoverServices(nil)
     }
 }

--- a/Gormsson/Source/Extensions/Gormsson+Notify.swift
+++ b/Gormsson/Source/Extensions/Gormsson+Notify.swift
@@ -53,6 +53,6 @@ extension Gormsson {
 
         guard let cbCharacteristic = get(characteristic), cbCharacteristic.isNotifying else { return }
 
-        current?.0.setNotifyValue(false, for: cbCharacteristic)
+        current?.setNotifyValue(false, for: cbCharacteristic)
     }
 }

--- a/Gormsson/Source/Gormsson.swift
+++ b/Gormsson/Source/Gormsson.swift
@@ -35,12 +35,12 @@ public final class Gormsson: NSObject {
     internal var didDiscoverBlock: ((CBPeripheral, GattAdvertisement) -> Void)?
 
     /// The current connected peripheral.
-    public var current: CBPeripheral?
+    public internal(set) var current: CBPeripheral?
     /// The last advertisement of the current peripheral
-    public var lastAdvertisement: GattAdvertisement?
+    public internal(set) var lastAdvertisement: GattAdvertisement?
 
     /// The current state of the manager.
-    @objc public dynamic var state: GormssonState = .unknown
+    @objc public internal(set) dynamic var state: GormssonState = .unknown
 
     /// Init a new Gormsson manager
     ///


### PR DESCRIPTION
I make the change to unbreak connect function, but I think saving the advertisement data should be on user hand. Not a big deal to save it anyway.